### PR TITLE
Adding torsion plots to GlycanDetail display

### DIFF
--- a/src/privateer/cpp/clipper-glyco.cpp
+++ b/src/privateer/cpp/clipper-glyco.cpp
@@ -3520,7 +3520,7 @@ bool MGlycan::link_sugars ( int link, clipper::MSugar& first_sugar, clipper::MSu
             DBG << "Torsions for link = " << link << ", phi = " << torsions[0] << "\t\tphi_c1c2o8c8 = " << torsions[5] << "\t\tpsi = " << torsions[1] << "\t\tomega_seven = " << torsions[2] << "\t\tomega_eight = " << torsions[3] << "\t\tomega_nine = " << torsions[4] << std::endl;
         }
         new_connection.set_linkage_atoms(donorAtom, acceptorAtom);
-        add_torsions_for_detected_linkages(clipper::Util::rad2d(phi), clipper::Util::rad2d(psi), first_sugar.type().trim(), donorAtom, next_sugar.type().trim(), acceptorAtom);
+        add_torsions_for_detected_linkages(clipper::Util::rad2d(phi), clipper::Util::rad2d(psi), first_sugar.type().trim(), donorAtom, next_sugar.type().trim(), acceptorAtom, first_sugar.seqnum(), next_sugar.seqnum());
         if(!torsions_zscore_database.database_array.empty())
         {
             float Phi = clipper::Util::rad2d(phi);
@@ -3627,7 +3627,7 @@ bool MGlycan::link_sugars ( int link, clipper::MSugar& first_sugar, clipper::MSu
             DBG << "Torsions for link = " << link << ", phi = " << torsions[0] << "\t\tphi_c1c2o8c8 = " << torsions[5] << "\t\tpsi = " << torsions[1] << "\t\tomega_seven = " << torsions[2] << "\t\tomega_eight = " << torsions[3] << "\t\tomega_nine = " << torsions[4] << std::endl;
         }
         new_connection.set_linkage_atoms(donorAtom, acceptorAtom);
-        add_torsions_for_detected_linkages(clipper::Util::rad2d(phi), clipper::Util::rad2d(psi), first_sugar.type().trim(), donorAtom, next_sugar.type().trim(), acceptorAtom);
+        add_torsions_for_detected_linkages(clipper::Util::rad2d(phi), clipper::Util::rad2d(psi), first_sugar.type().trim(), donorAtom, next_sugar.type().trim(), acceptorAtom, first_sugar.seqnum(), next_sugar.seqnum());
         if(!torsions_zscore_database.database_array.empty())
         {
             float Phi = clipper::Util::rad2d(phi);
@@ -3716,7 +3716,7 @@ bool MGlycan::link_sugars ( int link, clipper::MSugar& first_sugar, clipper::MSu
             DBG << "Torsions for link = " << link << ", phi = " << torsions[0] << "\t\tpsi = " << torsions[1] << "\t\tomega_six = " << torsions[2] << "\t\tomega_seven = " << torsions[3] << std::endl;
         }
         new_connection.set_linkage_atoms(donorAtom, acceptorAtom);
-        add_torsions_for_detected_linkages(clipper::Util::rad2d(phi), clipper::Util::rad2d(psi), first_sugar.type().trim(), donorAtom, next_sugar.type().trim(), acceptorAtom);
+        add_torsions_for_detected_linkages(clipper::Util::rad2d(phi), clipper::Util::rad2d(psi), first_sugar.type().trim(), donorAtom, next_sugar.type().trim(), acceptorAtom, first_sugar.seqnum(), next_sugar.seqnum());
         if(!torsions_zscore_database.database_array.empty())
         {
             float Phi = clipper::Util::rad2d(phi);
@@ -3789,7 +3789,7 @@ bool MGlycan::link_sugars ( int link, clipper::MSugar& first_sugar, clipper::MSu
             DBG << "Torsions for link = " << link << ", phi = " << torsions[0] << "\t\tpsi = " << torsions[1] << "\t\tomega = " << torsions[2] << std::endl;
         }
         new_connection.set_linkage_atoms(donorAtom, acceptorAtom);
-        add_torsions_for_detected_linkages(clipper::Util::rad2d(phi), clipper::Util::rad2d(psi), first_sugar.type().trim(), donorAtom, next_sugar.type().trim(), acceptorAtom);
+        add_torsions_for_detected_linkages(clipper::Util::rad2d(phi), clipper::Util::rad2d(psi), first_sugar.type().trim(), donorAtom, next_sugar.type().trim(), acceptorAtom, first_sugar.seqnum(), next_sugar.seqnum());
         if(!torsions_zscore_database.database_array.empty())
         {
             float Phi = clipper::Util::rad2d(phi);
@@ -3857,7 +3857,7 @@ bool MGlycan::link_sugars ( int link, clipper::MSugar& first_sugar, clipper::MSu
             DBG << "Torsions for link = " << link << ", phi = " << torsions[0] << "\t\tpsi = " << torsions[1] << std::endl;
         }
         new_connection.set_linkage_atoms(donorAtom, acceptorAtom);
-        add_torsions_for_detected_linkages(clipper::Util::rad2d(phi), clipper::Util::rad2d(psi), first_sugar.type().trim(), donorAtom, next_sugar.type().trim(), acceptorAtom);
+        add_torsions_for_detected_linkages(clipper::Util::rad2d(phi), clipper::Util::rad2d(psi), first_sugar.type().trim(), donorAtom, next_sugar.type().trim(), acceptorAtom, first_sugar.seqnum(), next_sugar.seqnum());
         if(!torsions_zscore_database.database_array.empty())
         {
             float Phi = clipper::Util::rad2d(phi);
@@ -3923,7 +3923,7 @@ bool MGlycan::link_sugars ( int link, clipper::MSugar& first_sugar, clipper::MSu
             DBG << "Torsions for link = " << link << ", phi = " << torsions[0] << "\t\tpsi = " << torsions[1] << std::endl;
         }
         new_connection.set_linkage_atoms(donorAtom, acceptorAtom);
-        add_torsions_for_detected_linkages(clipper::Util::rad2d(phi), clipper::Util::rad2d(psi), first_sugar.type().trim(), donorAtom, next_sugar.type().trim(), acceptorAtom);
+        add_torsions_for_detected_linkages(clipper::Util::rad2d(phi), clipper::Util::rad2d(psi), first_sugar.type().trim(), donorAtom, next_sugar.type().trim(), acceptorAtom, first_sugar.seqnum(), next_sugar.seqnum());
         if(!torsions_zscore_database.database_array.empty())
         {
             float Phi = clipper::Util::rad2d(phi);
@@ -3990,7 +3990,7 @@ bool MGlycan::link_sugars ( int link, clipper::MSugar& first_sugar, clipper::MSu
             DBG << "Torsions for link = " << link << ", phi = " << torsions[0] << "\t\tpsi = " << torsions[1] << std::endl;
         }
         new_connection.set_linkage_atoms(donorAtom, acceptorAtom);
-        add_torsions_for_detected_linkages(clipper::Util::rad2d(phi), clipper::Util::rad2d(psi), first_sugar.type().trim(), donorAtom, next_sugar.type().trim(), acceptorAtom);
+        add_torsions_for_detected_linkages(clipper::Util::rad2d(phi), clipper::Util::rad2d(psi), first_sugar.type().trim(), donorAtom, next_sugar.type().trim(), acceptorAtom, first_sugar.seqnum(), next_sugar.seqnum());
         if(!torsions_zscore_database.database_array.empty())
         {
             float Phi = clipper::Util::rad2d(phi);
@@ -4055,7 +4055,7 @@ bool MGlycan::link_sugars ( int link, clipper::MSugar& first_sugar, clipper::MSu
             DBG << "Torsions for link = " << link << ", phi = " << torsions[0] << "\t\tpsi = " << torsions[1] << std::endl;
         }
         new_connection.set_linkage_atoms(donorAtom, acceptorAtom);
-        add_torsions_for_detected_linkages(clipper::Util::rad2d(phi), clipper::Util::rad2d(psi), first_sugar.type().trim(), donorAtom, next_sugar.type().trim(), acceptorAtom);
+        add_torsions_for_detected_linkages(clipper::Util::rad2d(phi), clipper::Util::rad2d(psi), first_sugar.type().trim(), donorAtom, next_sugar.type().trim(), acceptorAtom, first_sugar.seqnum(), next_sugar.seqnum());
         if(!torsions_zscore_database.database_array.empty())
         {
             float Phi = clipper::Util::rad2d(phi);
@@ -4140,7 +4140,7 @@ bool MGlycan::link_sugars ( int link, clipper::MSugar& first_sugar, clipper::MSu
                 DBG << "Torsions for when next_sugar has 6 members, link = " << link << ", phi = " << torsions[0] << "\t\tpsi = " << torsions[1] << std::endl;
             }
             new_connection.set_linkage_atoms(donorAtom, acceptorAtom);
-            add_torsions_for_detected_linkages(clipper::Util::rad2d(phi), clipper::Util::rad2d(psi), first_sugar.type().trim(), donorAtom, next_sugar.type().trim(), acceptorAtom);
+            add_torsions_for_detected_linkages(clipper::Util::rad2d(phi), clipper::Util::rad2d(psi), first_sugar.type().trim(), donorAtom, next_sugar.type().trim(), acceptorAtom, first_sugar.seqnum(), next_sugar.seqnum());
             if(!torsions_zscore_database.database_array.empty())
             {
                 float Phi = clipper::Util::rad2d(phi);
@@ -4189,7 +4189,7 @@ bool MGlycan::link_sugars ( int link, clipper::MSugar& first_sugar, clipper::MSu
                 DBG << "Torsions for when next_sugar has 5 members, link = " << link << ", phi = " << torsions[0] << "\t\tpsi = " << torsions[1] << "\t\tomega = " << torsions[2] << std::endl;
             }
             new_connection.set_linkage_atoms(donorAtom, acceptorAtom);
-            add_torsions_for_detected_linkages(clipper::Util::rad2d(phi), clipper::Util::rad2d(psi), first_sugar.type().trim(), donorAtom, next_sugar.type().trim(), acceptorAtom);
+            add_torsions_for_detected_linkages(clipper::Util::rad2d(phi), clipper::Util::rad2d(psi), first_sugar.type().trim(), donorAtom, next_sugar.type().trim(), acceptorAtom, first_sugar.seqnum(), next_sugar.seqnum());
             if(!torsions_zscore_database.database_array.empty())
             {
                 float Phi = clipper::Util::rad2d(phi);
@@ -4212,13 +4212,17 @@ bool MGlycan::link_sugars ( int link, clipper::MSugar& first_sugar, clipper::MSu
     return false;
 }
 
-void MGlycan::add_torsions_for_detected_linkages(float Phi, float Psi, clipper::String first_residue_name, clipper::MAtom first_atom, clipper::String second_residue_name, clipper::MAtom second_atom)
+void MGlycan::add_torsions_for_detected_linkages(float Phi, float Psi, clipper::String first_residue_name, clipper::MAtom first_atom, clipper::String second_residue_name, clipper::MAtom second_atom, int first_residue_seqnum, int second_residue_seqnum)
 {
     if(!all_torsions_within_mglycan.empty())
     {
         auto search_result = std::find_if(all_torsions_within_mglycan.begin(), all_torsions_within_mglycan.end(), [first_residue_name, second_residue_name](MGlycanTorsionSummary& element)
         {
-            return first_residue_name == element.first_residue_name && second_residue_name == element.second_residue_name;
+            return 
+            first_residue_name == element.first_residue_name && 
+            second_residue_name == element.second_residue_name 
+            // NEED TO ADD CHECK FOR CORRECT LINKAGE DESIGNATION HERE
+            ;
         });
 
         if(search_result != std::end(all_torsions_within_mglycan))
@@ -4229,6 +4233,23 @@ void MGlycan::add_torsions_for_detected_linkages(float Phi, float Psi, clipper::
             found_torsion_description.linkage_descriptors.push_back(std::make_pair(donorPosition, acceptorPosition));
             found_torsion_description.atoms.push_back(std::make_pair(first_atom, second_atom));
             found_torsion_description.torsions.push_back(std::make_pair(Phi, Psi));
+
+            auto torsion_seach_result = std::find_if(found_torsion_description.combined_torsions.begin(), found_torsion_description.combined_torsions.end(), [donorPosition, acceptorPosition](std::pair<std::pair<std::string, std::string>, std::vector<std::pair<float,float>>>& element)
+                {
+                    return donorPosition == element.first.first && 
+                    acceptorPosition == element.first.second;
+                });
+
+            if (torsion_seach_result != std::end(found_torsion_description.combined_torsions)) { 
+                found_torsion_description.combined_torsions[torsion_seach_result-found_torsion_description.combined_torsions.begin()].second.push_back(std::make_pair(Phi, Psi));
+            }
+            else { 
+                std::pair<float,float> tmp_torsions = std::make_pair(Phi, Psi);
+                std::vector<std::pair<float,float>> tmp_torsion_vector; 
+                tmp_torsion_vector.push_back(tmp_torsions);
+                found_torsion_description.combined_torsions.push_back(std::make_pair(std::make_pair(donorPosition, acceptorPosition),tmp_torsion_vector));
+            }
+
         }
         else
         {
@@ -4245,6 +4266,13 @@ void MGlycan::add_torsions_for_detected_linkages(float Phi, float Psi, clipper::
             new_torsion.first_residue_name = first_residue_name;
             new_torsion.second_residue_name = second_residue_name;
             new_torsion.atoms.push_back(std::make_pair(first_atom, second_atom));
+            // If donorPosition adn acceptorPositon are in linkkage_ddesc
+            // Go to vector vector and add to that one not the top level vector 
+
+
+            std::vector<std::pair<float,float>> tmp_vector = {std::make_pair(Phi, Psi)};
+            new_torsion.combined_torsions.push_back(std::make_pair(std::make_pair(donorPosition, acceptorPosition), tmp_vector));
+            
             new_torsion.linkage_descriptors.push_back(std::make_pair(donorPosition, acceptorPosition));
             new_torsion.torsions.push_back(std::make_pair(Phi, Psi));
             all_torsions_within_mglycan.push_back(new_torsion);
@@ -4266,6 +4294,10 @@ void MGlycan::add_torsions_for_detected_linkages(float Phi, float Psi, clipper::
         first_torsion.first_residue_name = first_residue_name;
         first_torsion.second_residue_name = second_residue_name;
         first_torsion.atoms.push_back(std::make_pair(first_atom, second_atom));
+
+        std::vector<std::pair<float,float>> tmp_vector = {std::make_pair(Phi, Psi)};
+        first_torsion.combined_torsions.push_back(std::make_pair(std::make_pair(donorPosition, acceptorPosition), tmp_vector));
+
         first_torsion.linkage_descriptors.push_back(std::make_pair(donorPosition, acceptorPosition));
         first_torsion.torsions.push_back(std::make_pair(Phi, Psi));
 
@@ -5159,7 +5191,7 @@ void MGlycology::init ( const clipper::MiniMol& mmol, const clipper::MAtomNonBon
                         psi = clipper::Util::twopi() + psi;
 
                     mg.set_glycosylation_torsions ( clipper::Util::rad2d(phi), clipper::Util::rad2d(psi) );
-                    mg.add_torsions_for_detected_linkages(clipper::Util::rad2d(phi), clipper::Util::rad2d(psi), potential_n_roots[i].first.type().trim(), nd2, sugar.type().trim(), c1);
+                    mg.add_torsions_for_detected_linkages(clipper::Util::rad2d(phi), clipper::Util::rad2d(psi), potential_n_roots[i].first.type().trim(), nd2, sugar.type().trim(), c1, potential_n_roots[i].first.seqnum(), sugar.seqnum()); 
 
                     // This is hella cursed. A really cursed hacky implementation just to support linkage highlights in SNFG diagrams for ASN-NAG linkage.
                     // Ideally clipper::MGlycan::Linkage should have been reimplemented, but that would have taken too much time.
@@ -5316,7 +5348,7 @@ void MGlycology::init ( const clipper::MiniMol& mmol, const clipper::MAtomNonBon
                         psi = clipper::Util::twopi() + psi;
 
                     mg.set_glycosylation_torsions ( clipper::Util::rad2d(phi), clipper::Util::rad2d(psi) );
-                    mg.add_torsions_for_detected_linkages(clipper::Util::rad2d(phi), clipper::Util::rad2d(psi), potential_o_roots[i].first.type().trim(), og1, sugar.type().trim(), c1);
+                    mg.add_torsions_for_detected_linkages(clipper::Util::rad2d(phi), clipper::Util::rad2d(psi), potential_o_roots[i].first.type().trim(), og1, sugar.type().trim(), c1, potential_o_roots[i].first.seqnum(), sugar.seqnum());
 
 
                     list_of_glycans_modelled_as_glycosylation.push_back ( mg );
@@ -5400,7 +5432,7 @@ void MGlycology::init ( const clipper::MiniMol& mmol, const clipper::MAtomNonBon
                         psi = clipper::Util::twopi() + psi;
 
                     mg.set_glycosylation_torsions ( clipper::Util::rad2d(phi), clipper::Util::rad2d(psi) );
-                    mg.add_torsions_for_detected_linkages(clipper::Util::rad2d(phi), clipper::Util::rad2d(psi), potential_s_roots[i].first.type().trim(), sg, sugar.type().trim(), c1);
+                    mg.add_torsions_for_detected_linkages(clipper::Util::rad2d(phi), clipper::Util::rad2d(psi), potential_s_roots[i].first.type().trim(), sg, sugar.type().trim(), c1, potential_s_roots[i].first.seqnum(), sugar.seqnum());
 
 
                     list_of_glycans_modelled_as_glycosylation.push_back ( mg );
@@ -5488,7 +5520,7 @@ void MGlycology::init ( const clipper::MiniMol& mmol, const clipper::MAtomNonBon
 
 
                     mg.set_glycosylation_torsions ( clipper::Util::rad2d(phi), clipper::Util::rad2d(psi) );
-                    mg.add_torsions_for_detected_linkages(clipper::Util::rad2d(phi), clipper::Util::rad2d(psi), potential_c_roots[i].first.type().trim(), cd1, sugar.type().trim(), c1);
+                    mg.add_torsions_for_detected_linkages(clipper::Util::rad2d(phi), clipper::Util::rad2d(psi), potential_c_roots[i].first.type().trim(), cd1, sugar.type().trim(), c1, potential_c_roots[i].first.seqnum(), sugar.seqnum());
 
                     if ( linked[j].second.monomer()+3 < mmol[linked[j].second.polymer()].size() )
                     // Make sure that checks for consensus sequence do not occur outside the array, therefore causing segfaults.
@@ -5584,7 +5616,7 @@ void MGlycology::init ( const clipper::MiniMol& mmol, const clipper::MAtomNonBon
                         psi = clipper::Util::twopi() + psi;
 
                     mg.set_glycosylation_torsions ( clipper::Util::rad2d(phi), clipper::Util::rad2d(psi) );
-                    mg.add_torsions_for_detected_linkages(clipper::Util::rad2d(phi), clipper::Util::rad2d(psi), potential_p_roots[i].first.type().trim(), op, sugar.type().trim(), c1);
+                    mg.add_torsions_for_detected_linkages(clipper::Util::rad2d(phi), clipper::Util::rad2d(psi), potential_p_roots[i].first.type().trim(), op, sugar.type().trim(), c1, potential_p_roots[i].first.seqnum(), sugar.seqnum());
 
                     list_of_glycans_modelled_as_glycosylation.push_back ( mg );
                     break;

--- a/src/privateer/cpp/clipper-glyco.h
+++ b/src/privateer/cpp/clipper-glyco.h
@@ -578,6 +578,7 @@ namespace clipper
                 clipper::String second_residue_name; // acceptorResidue
                 std::vector<std::pair<clipper::MAtom, clipper::MAtom>> atoms; // .first = donorAtom, .second = acceptorAtom
                 std::vector<std::pair<std::string, std::string>> linkage_descriptors; // .first = donorPosition, .second = acceptorPosition
+                std::vector<std::pair<std::pair<std::string, std::string>, std::vector<std::pair<float,float>>>> combined_torsions; // This needs to be changed 
                 std::vector<std::pair<float, float>> torsions; // .first = Phi, .second = Psi
             };
 
@@ -831,18 +832,12 @@ namespace clipper
             }; // class Node
 
             bool link_sugars  ( int link, clipper::MSugar& first_sugar, clipper::MSugar& next_sugar, clipper::MAtom& donorAtom, clipper::MAtom& acceptorAtom, bool noncircular, privateer::json::GlobalTorsionZScore& torsions_zscore_database ); // true if there's been any problem
-            void add_torsions_for_detected_linkages(float Phi, float Psi, clipper::String first_residue_name, clipper::MAtom first_atom, clipper::String second_residue_name, clipper::MAtom second_atom);
+            void add_torsions_for_detected_linkages(float Phi, float Psi, clipper::String first_residue_name, clipper::MAtom first_atom, clipper::String second_residue_name, clipper::MAtom second_atom, int first_residue_seqnum, int second_residue_seqnum);
             std::vector<MGlycanTorsionSummary> return_torsion_summary_within_glycan() { return all_torsions_within_mglycan; };
             const std::pair < clipper::MMonomer, clipper::MSugar >& get_root () const { return this->root; }
             const clipper::String& get_type () const { return kind_of_glycan; } // n-glycan, o-glycan, s-glycan, c-glycan, p-glycan or ligand
             // std::string get_root_by_name () const { return get_root().first.type().trim() + "-" + get_root().first.id().trim() + "/" + get_chain().substr(0,1); }
-            std::string get_root_by_name () const { 
-                return get_root().second.type().trim() +
-                 "-" + get_root().second.id().trim().substr(0, get_root().second.id().trim().find(":")) + 
-                 "/" + get_root_sugar_chainID().trim().substr(0,1) + "_" + get_root().first.type().trim() + 
-                 "-" + get_root().first.id().trim().substr(0, get_root().first.id().trim().find(":")) + 
-                 "/" + get_chain().substr(0,1); }
-
+            std::string get_root_by_name () const { return get_root().second.type().trim() + "-" + get_root().second.id().trim() + "/" + get_root_sugar_chainID().trim().substr(0,1) + "_" + get_root().first.type().trim() + "-" + get_root().first.id().trim() + "/" + get_chain().substr(0,1); }
             std::string get_root_for_filename () { return  get_root().second.type().trim() + get_root().second.id().trim() + "-[" + get_root_sugar_chainID().trim().substr(0,1) + "]_[" + get_chain().trim().substr(0,1) + "]-" + get_root().first.type().trim() + get_root().first.id().trim(); }
 
             std::string write_ring_ext_restraints ( float weight );

--- a/webserver/src/components/GlycanDetail/GlycanDetail.jsx
+++ b/webserver/src/components/GlycanDetail/GlycanDetail.jsx
@@ -43,6 +43,7 @@ export default function GlycanDetail({tableData, hideMoorhen, setHideMoorhen, ro
 
     const [width, setWidth] = useState(800);
     const [height, setHeight] = useState(600);
+    const [torsionTab, setTorsionTab] = useState(0)
 
     return (
         <div className="flex-col justify-center items-center" style={{display: !hideMoorhen ? 'flex' : 'none'}}>
@@ -52,6 +53,7 @@ export default function GlycanDetail({tableData, hideMoorhen, setHideMoorhen, ro
                     <button onClick={() => {
                         setHideMoorhen(true);
                         window.scrollTo(0, scrollPosition);
+                        setTorsionTab(0)
                     }}>
                         <span className="">&#8592; Back To Table</span>
                     </button>
@@ -85,7 +87,7 @@ export default function GlycanDetail({tableData, hideMoorhen, setHideMoorhen, ro
             
             <h3 className="text-left text-xl w-full">Torsion Plots</h3>
 
-            <TorsionMultiPlot torsions={tableData[rowID].torsions}/>
+            <TorsionMultiPlot torsions={tableData[rowID].torsions} tab={torsionTab} setTab={setTorsionTab}/>
 
         </div>);
 }

--- a/webserver/src/components/GlycanDetail/GlycanDetail.jsx
+++ b/webserver/src/components/GlycanDetail/GlycanDetail.jsx
@@ -2,7 +2,8 @@ import {lazy, useCallback, useEffect, useState} from "react";
 import {MoorhenContainer, MoorhenContextProvider} from 'moorhen'
 import GlycanDetailInfoBox from "./GlycanDetailInfoBox";
 // import GlycanDetailTable from "./GlycanDetailTable";
-import TorsionPlot from "../TorsionPlot/TorsionPlot";
+// import TorsionPlot from "../TorsionPlot/TorsionPlot";
+import TorsionMultiPlot from "../TorsionPlot/TorsionMultiPlot";
 
 const GlycanDetailTable = lazy(() => import('./GlycanDetailTable'));
 
@@ -82,9 +83,9 @@ export default function GlycanDetail({tableData, hideMoorhen, setHideMoorhen, ro
 
             </MoorhenContextProvider>
             
-            {/* <h3 className="text-left text-xl w-full">Torsion Plots</h3>
+            <h3 className="text-left text-xl w-full">Torsion Plots</h3>
 
-            <TorsionPlot/> */}
+            <TorsionMultiPlot torsions={tableData[rowID].torsions}/>
 
         </div>);
 }

--- a/webserver/src/components/TorsionPlot/TorsionMultiPlot.jsx
+++ b/webserver/src/components/TorsionPlot/TorsionMultiPlot.jsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from "react";
+import TorsionPlot from "./TorsionPlot";
+
+
+function sortTorsions(torsions) { 
+    const linkage_set = new Set();
+
+    torsions.map((torsion) => {
+        let linkage_string = torsion.sugar_1 + "-" + torsion.atom_number_2 + "," + torsion.atom_number_1 + "-" + torsion.sugar_2
+        linkage_set.add(linkage_string)
+     })
+
+    const linkage_array = Array.from(linkage_set)
+    
+    const sorted_linkage_array = {}
+
+    linkage_array.map((item) => {
+        sorted_linkage_array[item] = []
+     })
+
+    torsions.map((torsion) => {
+        let linkage_string = torsion.sugar_1 + "-" + torsion.atom_number_2 + "," + torsion.atom_number_1 + "-" + torsion.sugar_2
+        sorted_linkage_array[linkage_string].push({"phi": torsion.phi, "psi": torsion.psi})
+    })
+
+    return [linkage_array, sorted_linkage_array]
+}
+
+function TorsionMultiPlotTabs({torsions, setTab}) { 
+
+    const [linkage_array, sorted_linkage_array] = sortTorsions(torsions)
+
+    console.log(linkage_array, sorted_linkage_array)
+
+    return (
+       linkage_array.map((item, index) => { 
+        return (
+            <div className="px-5"> 
+                <button className="bg-tertiary text-sec" onClick={
+                    () => {
+                        setTab(index)}
+                        }> <p className="p-1">{item}</p> </button>
+            </div>
+        )
+       })
+    )
+}
+
+export default function TorsionMultiPlot({torsions}) { 
+
+    const [tab, setTab] = useState(0)
+
+    const [linkage_array, sorted_linkage_array] = sortTorsions(torsions)
+    console.log(linkage_array, sorted_linkage_array)
+
+    useEffect(() => {console.log("TAB UODATED", tab)}, [tab])
+    
+    return (
+        <>  
+            <div className="flex">
+                <TorsionMultiPlotTabs torsions={torsions} setTab={setTab}/>   
+            </div>
+
+            <TorsionPlot linkage_type={linkage_array[tab]} sorted_torsion_list={sorted_linkage_array}/>
+        </>
+    )
+}

--- a/webserver/src/components/TorsionPlot/TorsionMultiPlot.jsx
+++ b/webserver/src/components/TorsionPlot/TorsionMultiPlot.jsx
@@ -6,7 +6,13 @@ function sortTorsions(torsions) {
     const linkage_set = new Set();
 
     torsions.map((torsion) => {
-        let linkage_string = torsion.sugar_1 + "-" + torsion.atom_number_2 + "," + torsion.atom_number_1 + "-" + torsion.sugar_2
+        let linkage_string = ""
+        if (torsion.sugar_1 == "ASN") {
+            linkage_string = torsion.sugar_1 + "-" + torsion.atom_number_2 + "," + torsion.atom_number_1 + "-" + torsion.sugar_2
+        }
+        else { 
+            linkage_string = torsion.sugar_2 + "-" + torsion.atom_number_2 + "," + torsion.atom_number_1 + "-" + torsion.sugar_1
+        }
         linkage_set.add(linkage_string)
      })
 
@@ -19,7 +25,14 @@ function sortTorsions(torsions) {
      })
 
     torsions.map((torsion) => {
-        let linkage_string = torsion.sugar_1 + "-" + torsion.atom_number_2 + "," + torsion.atom_number_1 + "-" + torsion.sugar_2
+        let linkage_string = ""
+        if (torsion.sugar_1 == "ASN") {
+            linkage_string = torsion.sugar_1 + "-" + torsion.atom_number_2 + "," + torsion.atom_number_1 + "-" + torsion.sugar_2
+        }
+        else { 
+            linkage_string = torsion.sugar_2 + "-" + torsion.atom_number_2 + "," + torsion.atom_number_1 + "-" + torsion.sugar_1
+        }        
+        
         sorted_linkage_array[linkage_string].push({"phi": torsion.phi, "psi": torsion.psi})
     })
 
@@ -30,38 +43,38 @@ function TorsionMultiPlotTabs({torsions, setTab}) {
 
     const [linkage_array, sorted_linkage_array] = sortTorsions(torsions)
 
-    console.log(linkage_array, sorted_linkage_array)
-
     return (
        linkage_array.map((item, index) => { 
         return (
-            <div className="px-5"> 
-                <button className="bg-tertiary text-sec" onClick={
-                    () => {
-                        setTab(index)}
-                        }> <p className="p-1">{item}</p> </button>
-            </div>
+
+            <li class="mr-2">
+                    <button class="inline-block p-4 border-b-2 border-transparent border-secondary rounded-t-lg hover:scale-105" onClick={() => {setTab(index)}}>{item}</button>
+            </li>
+
         )
        })
     )
 }
 
-export default function TorsionMultiPlot({torsions}) { 
+export default function TorsionMultiPlot({torsions, tab, setTab}) { 
 
-    const [tab, setTab] = useState(0)
 
     const [linkage_array, sorted_linkage_array] = sortTorsions(torsions)
-    console.log(linkage_array, sorted_linkage_array)
 
-    useEffect(() => {console.log("TAB UODATED", tab)}, [tab])
+    useEffect(() => {
+        console.log(tab)
+        setTab(0)
+    }, [])
     
     return (
-        <>  
-            <div className="flex">
-                <TorsionMultiPlotTabs torsions={torsions} setTab={setTab}/>   
+        <div className="flex flex-col align-middle justify-center items-center space-y-6 ">  
+            <div class="text-sm font-medium text-center text-gray-500 border-gray-200 text-gray-400 border-gray-700">
+                <ul class="flex flex-wrap -mb-px">                
+                    <TorsionMultiPlotTabs torsions={torsions} setTab={setTab}/>   
+                </ul>
             </div>
 
             <TorsionPlot linkage_type={linkage_array[tab]} sorted_torsion_list={sorted_linkage_array}/>
-        </>
+        </div>
     )
 }

--- a/webserver/src/components/TorsionPlot/TorsionPlot.jsx
+++ b/webserver/src/components/TorsionPlot/TorsionPlot.jsx
@@ -44,7 +44,7 @@ export default function TorsionPlot({linkage_type, sorted_torsion_list}) {
         })
         .catch((error) => {
             console.error(error);
-            console.log(linkage_type, " is not in the DB most likely ")
+            console.log(linkage_type," is not in the DB most likely ")
             setLinkageFound(false)
         });
         

--- a/webserver/src/components/TorsionPlot/TorsionPlot.jsx
+++ b/webserver/src/components/TorsionPlot/TorsionPlot.jsx
@@ -1,16 +1,36 @@
 import { useEffect, useState } from 'react';
 import Plot from 'react-plotly.js';
 
-export default function TorsionPlot({}) {
+export default function TorsionPlot({linkage_type, sorted_torsion_list}) {
+
+    const linkage_db = { 
+      "ASN-1,2-NAG": 'https://raw.githubusercontent.com/glycojones/privateer/master/data/linkage_torsions/unprocessed_files/ASN-NAG_reduced.json', 
+      "NAG-1,4-NAG": 'https://raw.githubusercontent.com/glycojones/privateer/master/data/linkage_torsions/unprocessed_files/NAG-NAG_reduced.json', 
+      "NAG-1,4-MAN": 'https://raw.githubusercontent.com/glycojones/privateer/master/data/linkage_torsions/unprocessed_files/NAG-MAN_reduced.json', 
+      "MAN-1,3-MAN": 'https://raw.githubusercontent.com/glycojones/privateer/master/data/linkage_torsions/unprocessed_files/MAN-MAN_reduced.json', 
+      "MAN-1,6-MAN": 'https://raw.githubusercontent.com/glycojones/privateer/master/data/linkage_torsions/unprocessed_files/MAN-MAN_reduced.json', 
+      "MAN-1,3-BMA": 'https://raw.githubusercontent.com/glycojones/privateer/master/data/linkage_torsions/unprocessed_files/BMA-MAN_reduced.json', 
+
+    }
+
+    const bin_db = {
+      "ASN-1,2-NAG": {start: 0, end: 360,size: 4},
+      "NAG-1,4-NAG": {start: -180, end: 180, size: 4},
+      "NAG-1,4-MAN": {start: -180, end: 180, size: 4},
+      "MAN-1,3-MAN": {start: -180, end: 180, size: 4},
+      "MAN-1,6-MAN": {start: -180, end: 180, size: 4},
+      "MAN-1,3-BMA": {start: -180, end: 180, size: 4},
+    }
 
     const [trace, setTrace] = useState({})
+    const [overlay, setOverlay] = useState({})
+
+    useEffect(() => {console.log("sorted_torsion_list updated", sorted_torsion_list)},[sorted_torsion_list])
 
     useEffect(() => {
-        fetch('https://raw.githubusercontent.com/glycojones/privateer/master/data/linkage_torsions/unprocessed_files/ASN-NAG_reduced.json')
+        fetch(linkage_db[linkage_type])
         .then((response) => response.json())
         .then((responseJson) => {
-            console.log(responseJson)
-
             let xData = []
             let yData = []
 
@@ -18,6 +38,7 @@ export default function TorsionPlot({}) {
                 xData.push(parseFloat(responseJson[i].Phi))
                 yData.push(parseFloat(responseJson[i].Psi))
             }
+
             setTrace({
                 x: xData,
                 y: yData,
@@ -35,25 +56,44 @@ export default function TorsionPlot({}) {
                     size: 4
                   },
                   autobiny: false,
-                  ybins: {
-                    start: 0,
-                    end: 360,
-                    size: 4
-                  },
+                  ybins: bin_db[linkage_type]
               })
 
         })
         .catch((error) => {
             console.error(error);
+            console.log(linkage_type, " is not in the DB most likely ")
         });
-    }, [])
+        
+        let overlay_phi = []
+        let overlay_psi = []
+
+        for (let i = 0; i < sorted_torsion_list[linkage_type].length; i++) { 
+          overlay_phi.push(sorted_torsion_list[linkage_type][i].phi)
+          overlay_psi.push(sorted_torsion_list[linkage_type][i].psi)
+
+        }
+
+        setOverlay({
+          x: overlay_phi, 
+          y: overlay_psi, 
+          mode: 'markers',
+          type: 'scatter',
+          marker: {
+            size: 8,
+            color: 'blue',
+            symbol: ['x']
+        },
+        })
+
+    }, [linkage_type])
 
     return (
       <Plot
         data={[
-            trace
+            trace, overlay 
         ]}
-        layout={ {width: 500, height: 500, title: 'ASN-NAG ', 
+        layout={ {width: 500, height: 500, title: linkage_type, 
         yaxis: {fixedrange: true},
         xaxis : {fixedrange: true},} }
       />

--- a/webserver/src/data/Constants.jsx
+++ b/webserver/src/data/Constants.jsx
@@ -40,32 +40,31 @@ export const COLUMNS = [
 ];
 
 export const linkage_db = { 
-    "BMA-1,6-MAN" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/BMA-1,6-MAN.json',
-    "ASN-1,2-NAG" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/ASN-1,1-NAG.json',
+    "GAL-1,4-NAG" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/GAL-1,4-NAG.json',
+    "NAG-1,2-MAN" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/NAG-1,2-MAN.json',
     "MAN-1,6-MAN" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/MAN-1,6-MAN.json',
-    "NAG-1,3-FUC" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/NAG-1,3-FUC.json',
+    "FUC-1,3-NAG" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/FUC-1,3-NAG.json',
+    "MAN-1,3-BMA" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/MAN-1,3-BMA.json',
     "NAG-1,4-NAG" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/NAG-1,4-NAG.json',
-    "NAG-1,6-FUC" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/NAG-1,6-FUC.json',
-    "NAG-1,4-BMA" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/NAG-1,4-BMA.json',
-    "BMA-1,3-MAN" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/BMA-1,3-MAN.json',
-    "NAG-1,4-GAL" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/NAG-1,4-GAL.json',
+    "ASN-1,2-NAG" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/ASN-1,2-NAG.json',
+    "MAN-1,6-BMA" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/MAN-1,6-BMA.json',
+    "BMA-1,4-NAG" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/BMA-1,4-NAG.json',
+    "FUC-1,6-NAG" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/FUC-1,6-NAG.json',
     "MAN-1,3-MAN" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/MAN-1,3-MAN.json',
     "MAN-1,2-MAN" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/MAN-1,2-MAN.json',
-    "MAN-1,2-NAG" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/MAN-1,2-NAG.json'
   }
 
-  export const bin_db = {
-    "ASN-1,2-NAG": {start: 0, end: 360,size: 4},
-    "BMA-1,6-MAN" : {start: -180, end: 180, size: 4},
-    "BMA-1,6-MAN" : {start: -180, end: 180, size: 4},
+export const bin_db = {
+    "ASN-1,2-NAG" : {start: 0, end: 360,size: 4},
+    "NAG-1,2-MAN" : {start: -180, end: 180, size: 4},
     "MAN-1,6-MAN" : {start: -180, end: 180, size: 4},
-    "NAG-1,3-FUC" : {start: -180, end: 180, size: 4},
+    "FUC-1,3-NAG" : {start: -180, end: 180, size: 4},
+    "MAN-1,3-BMA" : {start: -180, end: 180, size: 4},
     "NAG-1,4-NAG" : {start: -180, end: 180, size: 4},
-    "NAG-1,6-FUC" : {start: -180, end: 180, size: 4},
-    "NAG-1,4-BMA" : {start: -180, end: 180, size: 4},
-    "BMA-1,3-MAN" : {start: -180, end: 180, size: 4},
-    "NAG-1,4-GAL" : {start: -180, end: 180, size: 4},
+    "GAL-1,4-NAG" : {start: -180, end: 180, size: 4},
+    "MAN-1,6-BMA" : {start: -180, end: 180, size: 4},
+    "BMA-1,4-NAG" : {start: -180, end: 180, size: 4},
+    "FUC-1,6-NAG" : {start: -180, end: 180, size: 4},
     "MAN-1,3-MAN" : {start: -180, end: 180, size: 4},
     "MAN-1,2-MAN" : {start: -180, end: 180, size: 4},
-    "MAN-1,2-NAG" : {start: -180, end: 180, size: 4},
   }

--- a/webserver/src/data/Constants.jsx
+++ b/webserver/src/data/Constants.jsx
@@ -38,3 +38,34 @@ export const COLUMNS = [
     // },
 
 ];
+
+export const linkage_db = { 
+    "BMA-1,6-MAN" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/BMA-1,6-MAN.json',
+    "ASN-1,2-NAG" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/ASN-1,1-NAG.json',
+    "MAN-1,6-MAN" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/MAN-1,6-MAN.json',
+    "NAG-1,3-FUC" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/NAG-1,3-FUC.json',
+    "NAG-1,4-NAG" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/NAG-1,4-NAG.json',
+    "NAG-1,6-FUC" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/NAG-1,6-FUC.json',
+    "NAG-1,4-BMA" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/NAG-1,4-BMA.json',
+    "BMA-1,3-MAN" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/BMA-1,3-MAN.json',
+    "NAG-1,4-GAL" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/NAG-1,4-GAL.json',
+    "MAN-1,3-MAN" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/MAN-1,3-MAN.json',
+    "MAN-1,2-MAN" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/MAN-1,2-MAN.json',
+    "MAN-1,2-NAG" : 'https://raw.githubusercontent.com/Dialpuri/N-glycanTorsionDatabase/main/data_json/MAN-1,2-NAG.json'
+  }
+
+  export const bin_db = {
+    "ASN-1,2-NAG": {start: 0, end: 360,size: 4},
+    "BMA-1,6-MAN" : {start: -180, end: 180, size: 4},
+    "BMA-1,6-MAN" : {start: -180, end: 180, size: 4},
+    "MAN-1,6-MAN" : {start: -180, end: 180, size: 4},
+    "NAG-1,3-FUC" : {start: -180, end: 180, size: 4},
+    "NAG-1,4-NAG" : {start: -180, end: 180, size: 4},
+    "NAG-1,6-FUC" : {start: -180, end: 180, size: 4},
+    "NAG-1,4-BMA" : {start: -180, end: 180, size: 4},
+    "BMA-1,3-MAN" : {start: -180, end: 180, size: 4},
+    "NAG-1,4-GAL" : {start: -180, end: 180, size: 4},
+    "MAN-1,3-MAN" : {start: -180, end: 180, size: 4},
+    "MAN-1,2-MAN" : {start: -180, end: 180, size: 4},
+    "MAN-1,2-NAG" : {start: -180, end: 180, size: 4},
+  }

--- a/webserver/src/pages/Home/HomeSection.jsx
+++ b/webserver/src/pages/Home/HomeSection.jsx
@@ -33,9 +33,17 @@ export default function HomeSection() {
 
                 let table_data = [];
                 for (var i = 0; i < x.size(); i++) {
-                    table_data.push(x.get(i))
-                }
+                    let table_entry = x.get(i)
 
+                    let collected_torsions = []
+                    for(var j = 0; j < table_entry.torsions.size(); j++) { 
+                        collected_torsions.push(table_entry.torsions.get(j)); 
+                    }
+                    table_entry.torsions = collected_torsions
+                    table_data.push(table_entry)
+
+                }
+                
                 if (x.size() == 0 ) { 
                     setLoadingText("There were no detected glycans in this file.")
                     setFallBack(true)


### PR DESCRIPTION
As outlined in issue #42, displaying the torsion plot in addition to the current glycan torsions would be beneficial.

This pull request adds this feature, as shown in the screenshot below. 

![image](https://github.com/glycojones/privateer/assets/44945647/07fb9407-3e53-4a81-bf1c-ab151045c2aa)

Closes #42.

