### PR TITLE
Extend range of graph axes in GlycansVsYear.tsx

### DIFF
--- a/webapp/src/statistics/Graphs/GlycansVsYear.tsx
+++ b/webapp/src/statistics/Graphs/GlycansVsYear.tsx
@@ -204,7 +204,7 @@ export default function GlycansVsYear() {
                             automargin: true,
                             ticksuffix: ' ',
                             tickprefix: '    ',
-                            range: [-50, 1600],
+                            range: [-50, 1800],
                         },
                         yaxis2: {
                             title: {
@@ -222,7 +222,7 @@ export default function GlycansVsYear() {
                             automargin: true,
                             tickprefix: '  ',
                             ticksuffix: '   ',
-                            range: [-500, 16000],
+                            range: [-500, 18000],
                         },
                         xaxis: {
                             title: {


### PR DESCRIPTION
The commit increases the range of both the x-axis and y-axis in the GlycansVsYear.tsx file. This alteration ensures that all data points are properly and completely represented on the graph.