### PR TITLE
Fetch CIF files from the PDB preferentially

### DIFF
--- a/webapp/src/layouts/Footer.tsx
+++ b/webapp/src/layouts/Footer.tsx
@@ -4,7 +4,16 @@ export default function Footer(): ReactElement {
         <footer className="bg-gray w-full mt-auto">
             <div className="w-full mx-auto max-w-screen-xl p-4 flex items-center justify-center">
                 <span className="text-sm text-primary text-center justify-center dark:text-gray-400">
-                    <p>Spotted an issue? Please email us or <a href="https://github.com/glycojones/privateer/issues/new/choose" target='_blank' > submit a GitHub issue </a>
+                    <p>
+                        Spotted an issue? Please email us or{' '}
+                        <a
+                            href="https://github.com/glycojones/privateer/issues/new/choose"
+                            target="_blank"
+                            rel="noreferrer"
+                        >
+                            {' '}
+                            submit a GitHub issue{' '}
+                        </a>
                     </p>
                     York Structural Biology Laboratory
                     <br />

--- a/webapp/src/layouts/NavBar.tsx
+++ b/webapp/src/layouts/NavBar.tsx
@@ -92,7 +92,12 @@ export default function NavBar(): ReactElement {
                     </a>
                 </div>
                 <div className="h-12 w-12 mx-auto my-4 sm:w-12 sm:mt-12 sm:mr-12 flex items-center ">
-                    <a id="github" href={GITHUB_REPO} target="_blank">
+                    <a
+                        id="github"
+                        href={GITHUB_REPO}
+                        target="_blank"
+                        rel="noreferrer"
+                    >
                         <img
                             className="w-full hover:scale-125 transition-all hidden dark:block"
                             src="/github-mark.png"

--- a/webapp/src/modals/Citations/Citations.tsx
+++ b/webapp/src/modals/Citations/Citations.tsx
@@ -72,17 +72,42 @@ export default function CitationModal(props: {
                         McNicholas, S. J. & Agirre, J. (2024). Online
                         carbohydrate 3D structure validation with the Privateer
                         web app. Acta Cryst. F80.
-                        <p><a href="https://doi.org/10.1107/S2053230X24000359" target="_blank">https://doi.org/10.1107/S2053230X24000359</a></p>
+                        <p>
+                            <a
+                                href="https://doi.org/10.1107/S2053230X24000359"
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                https://doi.org/10.1107/S2053230X24000359
+                            </a>
+                        </p>
                     </strong>
                 </div>
 
-                 <div className="mt-4 flex flex-col space-y-2">
-                    <h3>If you have used the <b><i>Privateer Database</i></b>, please cite: </h3>
+                <div className="mt-4 flex flex-col space-y-2">
+                    <h3>
+                        If you have used the{' '}
+                        <b>
+                            <i>Privateer Database</i>
+                        </b>
+                        , please cite:{' '}
+                    </h3>
 
-                    <strong>Dialpuri, J. S.; Bagdonas, H.; Schofield, L. C.; Pham, P. T.; Holland, L.; Agirre, J. Beilstein J. Org. Chem. 2024, 20, 931–939.
-                        <p><a href="https://doi.org/10.3762/bjoc.20.83" target="_blank">https://doi.org/10.3762/bjoc.20.83</a></p>
+                    <strong>
+                        Dialpuri, J. S.; Bagdonas, H.; Schofield, L. C.; Pham,
+                        P. T.; Holland, L.; Agirre, J. Beilstein J. Org. Chem.
+                        2024, 20, 931–939.
+                        <p>
+                            <a
+                                href="https://doi.org/10.3762/bjoc.20.83"
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                https://doi.org/10.3762/bjoc.20.83
+                            </a>
+                        </p>
                     </strong>
-                 </div>
+                </div>
 
                 <div className="mt-4 flex flex-col space-y-2 font text-sm sm:text-base">
                     <h3>

--- a/webapp/src/shared/Information/Information.tsx
+++ b/webapp/src/shared/Information/Information.tsx
@@ -89,7 +89,11 @@ export function Information() {
                         <div className="flex flex-col gap-6 justify-center">
                             <span className="text-xl font-body">
                                 <b>Glycomics-Powered Validation</b>
-                                <a href={GLYCOMICS_CITATION} target="_blank">
+                                <a
+                                    href={GLYCOMICS_CITATION}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                >
                                     <svg
                                         className="inline pl-2 h-4 transition-all hover:h-5 fill-secondary"
                                         xmlns="http://www.w3.org/2000/svg"
@@ -119,7 +123,11 @@ export function Information() {
                         <div className="flex flex-col gap-6 justify-center">
                             <span className="text-xl font-body">
                                 <b>Linkage Torsion Validation</b>
-                                <a href={TORSIONS_CITATION} target="_blank">
+                                <a
+                                    href={TORSIONS_CITATION}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                >
                                     <svg
                                         className="inline pl-2 h-4 transition-all hover:h-5 fill-secondary"
                                         xmlns="http://www.w3.org/2000/svg"

--- a/webapp/src/utils/fetch_from_pdb.ts
+++ b/webapp/src/utils/fetch_from_pdb.ts
@@ -1,8 +1,7 @@
-export async function fetchPDB(PDBCode: string): Promise<string | void> {
-    if (PDBCode == null) {
-        return;
-    }
-    console.log('Fetching PDB ', PDBCode);
+async function fetchPDBFile(PDBCode: string): Promise<string | void> {
+    console.warn(
+        'The CIF file for this PDB could not be found, trying for the PDB'
+    );
     const pdbURL = `https://files.rcsb.org/download/${PDBCode.toUpperCase()}.pdb`;
 
     const file = fetch(pdbURL)
@@ -15,8 +14,37 @@ export async function fetchPDB(PDBCode: string): Promise<string | void> {
         .then(async (file) => {
             return file;
         })
-        .catch(() => {
-            throw new Error('PDB Not Found');
+        .catch(async (error) => {
+            return await Promise.reject(error);
+        });
+    return await file;
+}
+
+export async function fetchPDB(PDBCode: string): Promise<string | void> {
+    if (PDBCode == null) {
+        return;
+    }
+    // first try fetching the cif
+    console.log('Fetching PDB ', PDBCode);
+    const pdbURL = `https://files.rcsb.org/download/${PDBCode.toUpperCase()}.cif`;
+
+    const file = fetch(pdbURL)
+        .then(async (response) => {
+            if (!response.ok) {
+                throw new Error('Network error');
+            }
+            return await response.text();
+        })
+        .then(async (file) => {
+            return file;
+        })
+        .catch(async () => {
+            // if we can't find the cif, try the PDB, if that fails, then report the failure.
+            try {
+                return await fetchPDBFile(PDBCode);
+            } catch (e) {
+                return await Promise.reject(e);
+            }
         });
     return await file;
 }


### PR DESCRIPTION
# Description

This PR adds the functionality to first search for a CIF file in the PDB, then if one is not found, try to find a PDB. This should allow for larger, CIF-only structures to be validated.